### PR TITLE
Merge static libraries

### DIFF
--- a/cmake/Modules/drishti_get_library_location.cmake
+++ b/cmake/Modules/drishti_get_library_location.cmake
@@ -1,0 +1,37 @@
+include(CMakeParseArguments) # cmake_parse_arguments
+
+function(drishti_get_library_location)
+  set(optional)
+  set(one LIBRARY CONFIG RESULT)
+
+  # Introduce:
+  # * x_LIBRARY
+  # * x_CONFIG
+  # * x_RESULT
+  cmake_parse_arguments(x "${optional}" "${one}" "${multiple}" "${ARGV}")
+
+  string(COMPARE NOTEQUAL "${x_UNPARSED_ARGUMENTS}" "" has_unparsed)
+  if(has_unparsed)
+    message(FATAL_ERROR "Unparsed arguments: ${x_UNPARSED_ARGUMENTS}")
+  endif()
+
+  if(NOT TARGET "${x_LIBRARY}")
+    set("${x_RESULT}" "${x_LIBRARY}" PARENT_SCOPE)
+    return()
+  endif()
+
+  string(TOUPPER "${x_CONFIG}" config_upper)
+
+  get_target_property(location "${x_LIBRARY}" LOCATION_${config_upper})
+  if(location)
+    set("${x_RESULT}" "${location}" PARENT_SCOPE)
+    return()
+  endif()
+
+  get_target_property(location "${x_LIBRARY}" LOCATION)
+  if(NOT location)
+    message(FATAL_ERROR "Cannot determine location of librari '${x_LIBRARY}'")
+  endif()
+
+  set("${x_RESULT}" "${location}" PARENT_SCOPE)
+endfunction()

--- a/cmake/Modules/drishti_merge_get_all_dependencies.cmake
+++ b/cmake/Modules/drishti_merge_get_all_dependencies.cmake
@@ -1,0 +1,67 @@
+include(drishti_merge_print)
+
+include(CMakeParseArguments) # cmake_parse_arguments
+
+function(drishti_merge_get_all_dependencies)
+  set(optional)
+  set(one OUTPUT)
+  set(multiple INPUT ALREADY_PROCESSED)
+
+  # Introduce:
+  # * x_OUTPUT
+  # * x_INPUT
+  # * x_ALREADY_PROCESSED
+  cmake_parse_arguments(x "${optional}" "${one}" "${multiple}" "${ARGV}")
+
+  string(COMPARE NOTEQUAL "${x_UNPARSED_ARGUMENTS}" "" has_unparsed)
+  if(has_unparsed)
+    message(FATAL_ERROR "Unparsed arguments: ${x_UNPARSED_ARGUMENTS}")
+  endif()
+
+  drishti_merge_print("Searching dependencies for libraries:")
+  foreach(x ${x_INPUT})
+    drishti_merge_print(" * ${x}")
+  endforeach()
+
+  set(new_libraries)
+
+  foreach(x ${x_INPUT})
+    if(${x} IN_LIST x_ALREADY_PROCESSED)
+      continue()
+    endif()
+    if(NOT TARGET ${x})
+      continue()
+    endif()
+    get_property(link_libraries TARGET ${x} PROPERTY LINK_LIBRARIES)
+    if(NOT link_libraries)
+      continue()
+    endif()
+    list(APPEND new_libraries ${link_libraries})
+    drishti_merge_print("Dependencies for library '${x}':")
+    foreach(y ${link_libraries})
+      drishti_merge_print(" * ${y}")
+    endforeach()
+  endforeach()
+
+  set(
+      new_already_processed
+      ${x_ALREADY_PROCESSED}
+      ${x_INPUT}
+  )
+
+  list(REMOVE_DUPLICATES new_already_processed)
+  list(SORT new_already_processed)
+
+  if(NOT new_libraries)
+    set("${x_OUTPUT}" ${new_already_processed} PARENT_SCOPE)
+    return()
+  endif()
+
+  drishti_merge_get_all_dependencies(
+      INPUT ${new_libraries}
+      OUTPUT output
+      ALREADY_PROCESSED ${new_already_processed}
+  )
+
+  set("${x_OUTPUT}" ${output} PARENT_SCOPE)
+endfunction()

--- a/cmake/Modules/drishti_merge_libraries.cmake
+++ b/cmake/Modules/drishti_merge_libraries.cmake
@@ -1,0 +1,86 @@
+include(CMakeParseArguments) # cmake_parse_arguments
+
+cmake_policy(SET CMP0026 OLD) # drishti_merge_libraries_msvc use LOCATION
+
+include(drishti_merge_get_all_dependencies)
+include(drishti_merge_libraries_ar_ranlib)
+include(drishti_merge_libraries_msvc)
+include(drishti_merge_libraries_xcode)
+
+set(DRISHTI_MERGE_LIBRARIES_DIR "${CMAKE_CURRENT_LIST_DIR}")
+
+function(drishti_merge_libraries)
+  set(optional)
+  set(one FINAL)
+  set(multiple LIBRARIES)
+
+  # Introduce:
+  # * x_FINAL
+  # * x_LIBRARIES
+  cmake_parse_arguments(x "${optional}" "${one}" "${multiple}" "${ARGV}")
+
+  string(COMPARE NOTEQUAL "${x_UNPARSED_ARGUMENTS}" "" has_unparsed)
+  if(has_unparsed)
+    message(FATAL_ERROR "Unparsed arguments: ${x_UNPARSED_ARGUMENTS}")
+  endif()
+
+  if(TARGET "${x_FINAL}")
+    message(FATAL_ERROR "Target already exists: ${x_FINAL}")
+  endif()
+
+  set(working_dir "${CMAKE_CURRENT_BINARY_DIR}/_MergeLibraries")
+  set(libraries_list "${working_dir}/libraries.list")
+
+  add_library("${x_FINAL}" ${DRISHTI_MERGE_LIBRARIES_DIR}/source/foo.cpp)
+
+  drishti_merge_get_all_dependencies(
+      INPUT ${x_LIBRARIES}
+      OUTPUT all_dependencies
+  )
+
+  if(NOT all_dependencies)
+    message(FATAL_ERROR "The list of dependencies is empty")
+  endif()
+
+  foreach(x ${all_dependencies})
+    if(TARGET "${x}")
+      add_dependencies("${x_FINAL}" "${x}")
+    endif()
+  endforeach()
+
+  drishti_merge_print("Creating library '${x_FINAL}' from libraries:")
+  foreach(x ${all_dependencies})
+    drishti_merge_print(" * ${x}")
+  endforeach()
+
+  if(MSVC)
+    drishti_merge_libraries_msvc(
+        ALL_DEPENDENCIES
+        ${all_dependencies}
+        FINAL
+        ${x_FINAL}
+    )
+  elseif(XCODE)
+    drishti_merge_libraries_xcode(
+        ALL_DEPENDENCIES
+        ${all_dependencies}
+        LIBRARIES_LIST
+        ${libraries_list}
+        FINAL
+        ${x_FINAL}
+        WORKING_DIR
+        ${working_dir}
+    )
+  else()
+    drishti_merge_libraries_ar_ranlib(
+        ALL_DEPENDENCIES
+        ${all_dependencies}
+        LIBRARIES_LIST
+        ${libraries_list}
+        FINAL
+        ${x_FINAL}
+        WORKING_DIR
+        ${working_dir}
+    )
+  endif()
+endfunction()

--- a/cmake/Modules/drishti_merge_libraries_ar_ranlib.cmake
+++ b/cmake/Modules/drishti_merge_libraries_ar_ranlib.cmake
@@ -1,0 +1,62 @@
+include(CMakeParseArguments) # cmake_parse_arguments
+
+function(drishti_merge_libraries_ar_ranlib)
+  set(optional)
+  set(one LIBRARIES_LIST FINAL WORKING_DIR)
+  set(multiple ALL_DEPENDENCIES)
+
+  # Introduce:
+  # * x_LIBRARIES_LIST
+  # * x_FINAL
+  # * x_ALL_DEPENDENCIES
+  # * x_WORKING_DIR
+  cmake_parse_arguments(x "${optional}" "${one}" "${multiple}" "${ARGV}")
+
+  string(COMPARE NOTEQUAL "${x_UNPARSED_ARGUMENTS}" "" has_unparsed)
+  if(has_unparsed)
+    message(FATAL_ERROR "Unparsed arguments: ${x_UNPARSED_ARGUMENTS}")
+  endif()
+
+  if(NOT TARGET "${x_FINAL}")
+    message(FATAL_ERROR "Target doesn't exist: ${x_FINAL}")
+  endif()
+
+  string(COMPARE EQUAL "${x_WORKING_DIR}" "" is_empty)
+  if(is_empty)
+    message(FATAL_ERROR "WORKING_DIR empty")
+  endif()
+
+  set(append_commands "")
+  foreach(x ${x_ALL_DEPENDENCIES})
+    if(TARGET ${x})
+      set(lib "$<TARGET_FILE:${x}>")
+    else()
+      set(lib "${x}")
+    endif()
+    list(
+        APPEND
+        append_commands
+        COMMAND
+        "${CMAKE_COMMAND}"
+        "-DLIBRARIES_LIST=${x_LIBRARIES_LIST}"
+        "-DLIBRARY=${lib}"
+        -P "${DRISHTI_MERGE_LIBRARIES_DIR}/script/append.cmake"
+    )
+  endforeach()
+
+  add_custom_command(
+      TARGET "${x_FINAL}"
+      POST_BUILD
+      COMMAND "${CMAKE_COMMAND}" -E remove_directory "${x_WORKING_DIR}"
+      ${append_commands}
+      COMMAND
+          "${CMAKE_COMMAND}"
+          "-DLIBRARIES_LIST=${x_LIBRARIES_LIST}"
+          "-DWORKING_DIR=${x_WORKING_DIR}"
+          "-DCMAKE_AR=${CMAKE_AR}"
+          "-DCMAKE_RANLIB=${CMAKE_RANLIB}"
+          "-DFINAL_LIBRARY=$<TARGET_FILE:${x_FINAL}>"
+          -P "${DRISHTI_MERGE_LIBRARIES_DIR}/script/create_by_ar_ranlib.cmake"
+      COMMENT "Creating library '${x_FINAL}'"
+  )
+endfunction()

--- a/cmake/Modules/drishti_merge_libraries_msvc.cmake
+++ b/cmake/Modules/drishti_merge_libraries_msvc.cmake
@@ -1,0 +1,59 @@
+include(CMakeParseArguments) # cmake_parse_arguments
+
+include(drishti_get_library_location)
+
+function(drishti_merge_libraries_msvc)
+  set(optional)
+  set(one FINAL)
+  set(multiple ALL_DEPENDENCIES)
+
+  # Introduce:
+  # * x_FINAL
+  # * x_ALL_DEPENDENCIES
+  cmake_parse_arguments(x "${optional}" "${one}" "${multiple}" "${ARGV}")
+
+  string(COMPARE NOTEQUAL "${x_UNPARSED_ARGUMENTS}" "" has_unparsed)
+  if(has_unparsed)
+    message(FATAL_ERROR "Unparsed arguments: ${x_UNPARSED_ARGUMENTS}")
+  endif()
+
+  if(NOT TARGET "${x_FINAL}")
+    message(FATAL_ERROR "Target doesn't exist: ${x_FINAL}")
+  endif()
+
+  string(COMPARE EQUAL "${CMAKE_CFG_INTDIR}" "." is_single)
+  if(is_single)
+    set(extra_linker_flags "")
+    foreach(x ${x_ALL_DEPENDENCIES})
+      drishti_get_library_location(
+          LIBRARY "${x}"
+          CONFIG "${CMAKE_BUILD_TYPE}"
+          RESULT location
+      )
+      set(extra_linker_flags "${extra_linker_flags} ${location}")
+    endforeach()
+
+    set_target_properties(
+        "${x_FINAL}" PROPERTIES STATIC_LIBRARY_FLAGS "${extra_linker_flags}"
+    )
+    return()
+  endif()
+
+  foreach(config ${CMAKE_CONFIGURATION_TYPES})
+    string(TOUPPER "${config}" config_upper)
+
+    set(extra_linker_flags "")
+    foreach(x ${x_ALL_DEPENDENCIES})
+      drishti_get_library_location(
+          LIBRARY "${x}"
+          CONFIG "${config_upper}"
+          RESULT location
+      )
+      set(extra_linker_flags "${extra_linker_flags} ${location}")
+    endforeach()
+
+    set_target_properties(
+        "${x_FINAL}" PROPERTIES STATIC_LIBRARY_FLAGS_${config_upper} "${extra_linker_flags}"
+    )
+  endforeach()
+endfunction()

--- a/cmake/Modules/drishti_merge_libraries_xcode.cmake
+++ b/cmake/Modules/drishti_merge_libraries_xcode.cmake
@@ -1,0 +1,70 @@
+include(CMakeParseArguments) # cmake_parse_arguments
+
+function(drishti_merge_libraries_xcode)
+  set(optional)
+  set(one LIBRARIES_LIST FINAL WORKING_DIR)
+  set(multiple ALL_DEPENDENCIES)
+
+  # Introduce:
+  # * x_LIBRARIES_LIST
+  # * x_FINAL
+  # * x_ALL_DEPENDENCIES
+  # * x_WORKING_DIR
+  cmake_parse_arguments(x "${optional}" "${one}" "${multiple}" "${ARGV}")
+
+  string(COMPARE NOTEQUAL "${x_UNPARSED_ARGUMENTS}" "" has_unparsed)
+  if(has_unparsed)
+    message(FATAL_ERROR "Unparsed arguments: ${x_UNPARSED_ARGUMENTS}")
+  endif()
+
+  if(NOT TARGET "${x_FINAL}")
+    message(FATAL_ERROR "Target doesn't exist: ${x_FINAL}")
+  endif()
+
+  string(COMPARE EQUAL "${x_WORKING_DIR}" "" is_empty)
+  if(is_empty)
+    message(FATAL_ERROR "WORKING_DIR empty")
+  endif()
+
+  set(append_commands "")
+  foreach(x ${x_ALL_DEPENDENCIES})
+    if(TARGET ${x})
+      set(lib "$<TARGET_FILE:${x}>")
+    else()
+      set(lib "${x}")
+    endif()
+    list(
+        APPEND
+        append_commands
+        COMMAND
+        "${CMAKE_COMMAND}"
+        "-DLIBRARIES_LIST=${x_LIBRARIES_LIST}"
+        "-DLIBRARY=${lib}"
+        -P "${DRISHTI_MERGE_LIBRARIES_DIR}/script/append.cmake"
+    )
+  endforeach()
+
+  set(cmd xcrun -f libtool)
+  execute_process(
+      COMMAND ${cmd}
+      RESULT_VARIABLE result
+      OUTPUT_VARIABLE libtool_path
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  if(NOT result EQUAL 0)
+    message(FATAL_ERROR "Command failed: " ${cmd})
+  endif()
+
+  add_custom_command(
+      TARGET "${x_FINAL}"
+      POST_BUILD
+      COMMAND "${CMAKE_COMMAND}" -E remove_directory "${x_WORKING_DIR}"
+      ${append_commands}
+      COMMAND
+          "${libtool_path}"
+          -static
+          -o "$<TARGET_FILE:${x_FINAL}>"
+          -filelist "${x_LIBRARIES_LIST}"
+      COMMENT "Creating library '${x_FINAL}'"
+  )
+endfunction()

--- a/cmake/Modules/drishti_merge_print.cmake
+++ b/cmake/Modules/drishti_merge_print.cmake
@@ -1,0 +1,3 @@
+function(drishti_merge_print)
+  message("[merge static] " ${ARGV})
+endfunction()

--- a/cmake/Modules/script/append.cmake
+++ b/cmake/Modules/script/append.cmake
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.1)
+
+if("${LIBRARIES_LIST}" STREQUAL "")
+  message(FATAL_ERROR "LIBRARIES_LIST is empty")
+endif()
+
+if("${LIBRARY}" STREQUAL "")
+  message(FATAL_ERROR "LIBRARY is empty")
+endif()
+
+if(NOT EXISTS "${LIBRARY}")
+  message(FATAL_ERROR "Library file not found: ${LIBRARY}")
+endif()
+
+file(APPEND "${LIBRARIES_LIST}" "${LIBRARY}\n")

--- a/cmake/Modules/script/create_by_ar_ranlib.cmake
+++ b/cmake/Modules/script/create_by_ar_ranlib.cmake
@@ -1,0 +1,147 @@
+cmake_minimum_required(VERSION 3.1)
+
+include("${CMAKE_CURRENT_LIST_DIR}/../drishti_merge_print.cmake")
+
+if("${LIBRARIES_LIST}" STREQUAL "")
+  message(FATAL_ERROR "LIBRARIES_LIST is empty")
+endif()
+
+if(NOT EXISTS "${LIBRARIES_LIST}")
+  message(FATAL_ERROR "File not found: '${LIBRARIES_LIST}'")
+endif()
+
+if("${WORKING_DIR}" STREQUAL "")
+  message(FATAL_ERROR "WORKING_DIR is empty")
+endif()
+
+if(NOT EXISTS "${WORKING_DIR}")
+  message(FATAL_ERROR "Directory not found: '${WORKING_DIR}'")
+endif()
+
+if("${CMAKE_AR}" STREQUAL "")
+  message(FATAL_ERROR "CMAKE_AR is empty")
+endif()
+
+if(NOT EXISTS "${CMAKE_AR}")
+  message(FATAL_ERROR "'ar' not found: '${CMAKE_AR}'")
+endif()
+
+if("${CMAKE_RANLIB}" STREQUAL "")
+  message(FATAL_ERROR "CMAKE_RANLIB is empty")
+endif()
+
+if(NOT EXISTS "${CMAKE_RANLIB}")
+  message(FATAL_ERROR "'ranlib' not found: '${CMAKE_RANLIB}'")
+endif()
+
+if("${FINAL_LIBRARY}" STREQUAL "")
+  message(FATAL_ERROR "FINAL_LIBRARY is empty")
+endif()
+
+if(NOT EXISTS "${FINAL_LIBRARY}")
+  message(FATAL_ERROR "Library not found: '${FINAL_LIBRARY}'")
+endif()
+
+file(STRINGS "${LIBRARIES_LIST}" libraries_list)
+
+set(disintegration_top "${WORKING_DIR}/disintegration")
+
+file(REMOVE "${FINAL_LIBRARY}")
+
+foreach(x ${libraries_list})
+  if(NOT EXISTS "${x}")
+    message(FATAL_ERROR "Library not found: '${x}'")
+  endif()
+  get_filename_component(lib_name "${x}" NAME)
+
+  set(disintegration_dir "${disintegration_top}/${lib_name}")
+  if(EXISTS "${disintegration_dir}")
+    message(
+        FATAL_ERROR
+        "Directory already exists: '${disintegration_dir}' (library name duplicate)"
+    )
+  endif()
+  file(MAKE_DIRECTORY "${disintegration_dir}")
+
+  # Verify that there are no two objects with the same name in archive
+  # * http://www.linux.org/threads/same-filename-o-in-a.8834/
+  # * http://stackoverflow.com/a/3821949/2288008 (second comment)
+  set(cmd "${CMAKE_AR}" t "${x}")
+  execute_process(
+      COMMAND
+      ${cmd}
+      RESULT_VARIABLE result
+      OUTPUT_VARIABLE ar_t_output
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  if(NOT result EQUAL 0)
+    message(FATAL_ERROR "Command failed: " ${cmd})
+  endif()
+  string(REPLACE "\n" " " list_of_objects "${ar_t_output}")
+  separate_arguments(list_of_objects)
+  list(LENGTH list_of_objects original_len)
+  list(REMOVE_DUPLICATES list_of_objects)
+  list(LENGTH list_of_objects modified_len)
+  if(NOT original_len EQUAL modified_len)
+    message(
+        FATAL_ERROR
+        "Unsupported: objects with the same name detected"
+        " in library '${x}': ${ar_t_output}"
+    )
+  endif()
+
+  set(cmd "${CMAKE_AR}" x "${x}")
+  execute_process(
+      COMMAND
+      ${cmd}
+      WORKING_DIRECTORY "${disintegration_dir}"
+      RESULT_VARIABLE result
+  )
+  if(NOT result EQUAL 0)
+    message(FATAL_ERROR "Command failed " ${cmd})
+  endif()
+
+  if(NOT EXISTS "${FINAL_LIBRARY}")
+    drishti_merge_print("Creating library:")
+    drishti_merge_print("* '${FINAL_LIBRARY}'")
+    drishti_merge_print("From objects of:")
+    drishti_merge_print("* '${x}'")
+    set(flags "qc")
+  else()
+    drishti_merge_print("Appending objects of:")
+    drishti_merge_print("* '${x}'")
+    set(flags "q")
+  endif()
+
+  file(
+      GLOB
+      list_of_objects
+      LIST_DIRECTORIES false
+      "${disintegration_dir}/*"
+  )
+
+  set(cmd ${CMAKE_AR} ${flags} ${FINAL_LIBRARY} ${list_of_objects})
+  execute_process(
+      COMMAND
+      ${cmd}
+      WORKING_DIRECTORY "${disintegration_dir}"
+      RESULT_VARIABLE result
+  )
+  if(NOT result EQUAL 0)
+    message(FATAL_ERROR "Command failed " ${cmd})
+  endif()
+endforeach()
+
+set(cmd ${CMAKE_RANLIB} ${FINAL_LIBRARY})
+execute_process(
+    COMMAND
+    ${cmd}
+    WORKING_DIRECTORY "${WORKING_DIR}"
+    RESULT_VARIABLE result
+)
+if(NOT result EQUAL 0)
+  message(FATAL_ERROR "Command failed " ${cmd})
+endif()
+
+drishti_merge_print("Done:")
+drishti_merge_print("* '${FINAL_LIBRARY}'")

--- a/cmake/Modules/source/foo.cpp
+++ b/cmake/Modules/source/foo.cpp
@@ -1,0 +1,2 @@
+void drishti_merge_static_libraries_dummy_function() {
+}


### PR DESCRIPTION
Merge static libraries with `ar`/`ranlib` tools. Should work for Linux, Android, OSX Makefile. Xcode and Visual Studio coming soon.

Usage:
```cmake
include(drishti_merge_libraries)

add_library(foo foo.cpp)
add_library(boo boo.cpp)

drishti_merge_libraries(
    LIBRARIES
    foo
    boo
    FINAL
    my_world
)

add_executable(my my.cpp)
target_link_libraries(my PUBLIC my_world)
```