### PR TITLE
Remove redundant

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,9 +155,6 @@ drishti_always_full_rpath()
 ###########################
 
 if(XCODE)
-
-  set(CMAKE_CONFIGURATION_TYPES "Debug;Release;MinSizeRel;RelWithDebInfo")
-
   set(CMAKE_XCODE_ATTRIBUTE_GCC_INLINES_ARE_PRIVATE_EXTERN "YES")
   set(CMAKE_XCODE_ATTRIBUTE_GCC_SYMBOLS_PRIVATE_EXTERN "YES")
 


### PR DESCRIPTION
CMAKE_CONFIGURATION_TYPES set in 'project' with 4 default values already