### PR TITLE
Fix Visual Studio compile errors

### DIFF
--- a/src/app/qt/facefilter/QMLCameraManager.cpp
+++ b/src/app/qt/facefilter/QMLCameraManager.cpp
@@ -78,10 +78,10 @@ QMLCameraManager::create(QQuickItem* root, std::shared_ptr<spdlog::logger>& logg
     cameraManager = drishti::core::make_unique<QMLCameraManagerApple>(camera, logger);
 #elif defined(Q_OS_WIN)
     // TODO: Specialize
-    cameraManager = drishti::core::make_unique<QMLCameraManage>(camera, logger);
+    cameraManager = drishti::core::make_unique<QMLCameraManager>(camera, logger);
 #elif defined(Q_OS_UNIX)
     // TODO: Specialize
-    cameraManager = drishti::core::make_unique<QMLCameraManage>(camera, logger);
+    cameraManager = drishti::core::make_unique<QMLCameraManager>(camera, logger);
 #endif
 
     return cameraManager;

--- a/src/app/qt/facefilter/QtFaceDetectorFactory.h
+++ b/src/app/qt/facefilter/QtFaceDetectorFactory.h
@@ -3,6 +3,8 @@
 
 #include "drishti/face/FaceDetectorFactory.h"
 
+#include <functional> // std::function
+
 // clang-format off
 namespace drishti
 {


### PR DESCRIPTION
Note: currently failing with `#error: gl2.h included before glew.h` error.