### PR TITLE
promote mirrored options from drishti-upload (CI project) to top level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,16 @@ else()
   set(DRISHTI_HUNTER_GATE_URL "https://github.com/ruslo/hunter/archive/v0.19.237.tar.gz")
   set(DRISHTI_HUNTER_GATE_SHA1 "b64ad42b7ef398a7332f5f4a98cf7bbfd38ca8d0")
   set(DRISHTI_HUNTER_CONFIG "${CMAKE_CURRENT_LIST_DIR}/cmake/Hunter/config.cmake")
+
+  # Maintain one-to-one correspondence with options in drishti-upload.
+  option(DRISHTI_BUILD_OGLES_GPGPU "Build with OGLES_GPGPU" ON)
+  option(DRISHTI_BUILD_ACF "Drishti ACF lib" ON)
+  option(DRISHTI_OPENGL_ES3 "Support OpenGL ES 3.0 (default 2.0)" OFF)
+  option(DRISHTI_BUILD_MIN_SIZE "Build minimum size lib (exclude training)" ON)
+  option(DRISHTI_BUILD_OPENCV_WORLD "Build OpenCV world (monolithic lib)" ON)
+  option(DRISHTI_SERIALIZE_WITH_CVMATIO "Perform serialization with cvmatio" OFF)
+  option(DRISHTI_BUILD_OPENCV_EXTRA "Build opencv_contrib modules" OFF)
+  
 endif()
 
 include("cmake/HunterGate.cmake")

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -30,14 +30,6 @@ endif()
     
 hunter_config(dlib VERSION ${dlib_version} CMAKE_ARGS ${dlib_cmake_args})
 
-# Maintain one-to-one correspondence with options in drishti-upload
-option(DRISHTI_BUILD_OGLES_GPGPU "Build with OGLES_GPGPU" ON)
-option(DRISHTI_BUILD_ACF "Drishti ACF lib" ON)
-option(DRISHTI_OPENGL_ES3 "Support OpenGL ES 3.0 (default 2.0)" OFF)
-option(DRISHTI_BUILD_MIN_SIZE "Build minimum size lib (exclude training)" ON)
-option(DRISHTI_BUILD_OPENCV_WORLD "Build OpenCV world (monolithic lib)" ON)
-option(DRISHTI_SERIALIZE_WITH_CVMATIO "Perform serialization with cvmatio" OFF)
-
 set(acf_cmake_args
   ACF_BUILD_TESTS=OFF 
   ACF_BUILD_EXAMPLES=OFF

--- a/src/lib/drishti/CMakeLists.txt
+++ b/src/lib/drishti/CMakeLists.txt
@@ -6,6 +6,12 @@ include(drishti_hide)
 include(drishti_strip)
 include(drishti_split_debug_symbols)
 
+option(DRISHTI_PRINT_ALL "Print all variables" OFF)
+if(DRISHTI_PRINT_ALL)
+  include(drishti_print_env_var)
+  drishti_print_env_var()
+endif()
+
 ## Customize linker flags
 include(CheckCCompilerFlag)
 if(NOT MSVC)


### PR DESCRIPTION
A set of options required by the drishti-upload CI cache project is mirrored internally in the drishti HunterGate LOCAL config.cmake in all cases where drishti-upload is skipped, as is the case when using drishti as a package through hunter.  Since these are mirrored in the Hunter LOCAL config cmake/Hunter/config.cmake, they are skipped when drishti is used through Hunter as top level project that provides its’ own LOCAL cmake/Hunter/config.cmake file in the HunterGate call.  A few of these options are central to the build logic, so they promoted to the top level CMakeLists.txt file in cases where drishti-upload is not used.  This simple change of scope ensures the hunter package will preserve the correct option related logic.

Note: This logic (in particular the need for a drishti-upload project for CI builds) will be simplified when the cache uploads are managed directly by hunter (soon!).

* mirror drishti-upload options in top level cmake when drishti-upload isn’t used
* add option to support printing all cmake variables inside hunter for debugging (default off)