### PR TITLE
add 'vs-15-2017' toolchain to appveyor 

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,11 +7,12 @@ environment:
 
   matrix:
 
-    - TOOLCHAIN: "vs-14-2015-sdk-8-1"
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      TOOLCHAIN: "vs-15-2017"
       CONFIG: Release
 
     - TOOLCHAIN: "vs-14-2015-sdk-8-1"
-      CONFIG: Debug
+      CONFIG: Release
 
     - TOOLCHAIN: "vs-14-2015-win64-sdk-8-1"
       CONFIG: Release


### PR DESCRIPTION
This also updates the gtest package to 1.8.0-hunter-p11 to overcome some VS 2017 warning-as-errors in the gtest lib.