### PR TITLE
fix rpath format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,9 +60,8 @@ if(DRISHTI_USE_DRISHTI_UPLOAD)
   )
   endif()
 else()
-  set(DRISHTI_HUNTER_GATE_URL "https://github.com/ruslo/hunter/archive/v0.21.9.tar.gz")
-  set(DRISHTI_HUNTER_GATE_SHA1 "0056188988906abb63a06c6f1aaef01832c62b74")
-
+  set(DRISHTI_HUNTER_GATE_URL "https://github.com/ruslo/hunter/archive/v0.21.15.tar.gz")
+  set(DRISHTI_HUNTER_GATE_SHA1 "f52db0eb7c1663d4cdedbda82b61b23d5d6a75d9")
   if(HUNTER_ENABLED AND NOT DRISHTI_IS_REPO_BUILD)
     # DEPENDENCY: if(HUNTER_ENABLE): we are being used as a dependency from
     # another project and we will use the config.cmake from the parent project.
@@ -94,7 +93,7 @@ endif()
 ### Drishti project ###
 #######################
 
-project(drishtisdk VERSION 0.11.1)
+project(drishtisdk VERSION 0.12.0)
 
 set(CMAKE_POLICY_DEFAULT_CMP0069 NEW) # for 3rd parties added by add_subdirectory
 

--- a/cmake/Modules/drishti_set_rpath.cmake
+++ b/cmake/Modules/drishti_set_rpath.cmake
@@ -1,9 +1,10 @@
 #https://cmake.org/Wiki/CMake_RPATH_handling
 
 macro(drishti_set_rpath)
-  set(DRISHTI_ORIGIN "$ORIGIN")
   if (APPLE)
     set(DRISHTI_ORIGIN "@loader_path")
+  else()
+    set(DRISHTI_ORIGIN "$ORIGIN")
   endif()
-  set(CMAKE_INSTALL_RPATH "${DRISHTI_ORIGIN}/../lib:${DRISHTI_ORIGIN}/")
+  set(CMAKE_INSTALL_RPATH "${DRISHTI_ORIGIN}/../lib" "${DRISHTI_ORIGIN}")
 endmacro()

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -54,5 +54,4 @@ endif()
 target_include_directories(drishti PUBLIC $<BUILD_INTERFACE:${DRISHTI_INCLUDE_DIRECTORIES}/drishti>)
 add_library(drishti::drishti ALIAS drishti)
 
-set(DRISHTI_BUNDLE_SDK_SAMPLES ON) # indicate they will be bundled
 add_subdirectory(sdk)

--- a/src/app/sdk/CMakeLists.txt
+++ b/src/app/sdk/CMakeLists.txt
@@ -8,7 +8,7 @@
 # etc).
 ################################################################################
 
-if(NOT DRISHTI_BUNDLE_SDK_SAMPLES)
+if(NOT TARGET drishti::drishti)
 
   set(DRISHTI_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/src/app/sdk/face/CMakeLists.txt
+++ b/src/app/sdk/face/CMakeLists.txt
@@ -57,4 +57,5 @@ endif()
 if(DRISHTI_HAVE_LOCALECONV)
   target_compile_definitions(drishti-face-test PUBLIC DRISHTI_HAVE_LOCALECONV=1)
 endif()
+
 install(TARGETS drishti-face-test DESTINATION bin)

--- a/src/app/sdk/face/config/orbbec_astra_pro.json
+++ b/src/app/sdk/face/config/orbbec_astra_pro.json
@@ -1,17 +1,17 @@
 {
-    "acfCalibration": 0.015,
+    "acfCalibration": 0.002,
     "doAnnotation": true,
     "doSimplePipeline": false,
     "faceFinderInterval": 0.0,
-    "videoWidth": 1920,
-    "videoHeight": 1080,
+    "videoWidth": 1280,
+    "videoHeight": 720,
     "focalLength": 1618.0,
-    "minDetectionDistance": 0.0,    
-    "maxDetectionDistance": 3.0,
+    "minDetectionDistance": 0.1,    
+    "maxDetectionDistance": 2.0,
     "maxTrackMisses": 2,
     "minFaceSeparation": 0.1,
     "minTrackHits": 3,
-    "multiFace": false,
+    "multiFace": true,
     "regressorCropScale": 1.1,
     "doCpuAcf": false
 }

--- a/src/lib/drishti/CMakeLists.txt
+++ b/src/lib/drishti/CMakeLists.txt
@@ -282,6 +282,9 @@ if((NOT DRISHTI_BUILD_SHARED_SDK) AND DRISHTI_BUILD_MERGED_SDK)
   list(APPEND drishti_interface_libs drishti)
 endif()
 
+# ALIAS target allow us to have same interface while including project
+add_library(drishti::drishti ALIAS drishti)
+
 if(DRISHTI_BUILD_SHARED_SDK AND NOT (IOS AND DRISHTI_BUILD_MERGED_SDK))
   # Error: ld: Assertion failed: (0 && "need to handle arm64 -r reloc")
   #drishti_strip(drishti)

--- a/src/lib/drishti/drishti/Context.cpp
+++ b/src/lib/drishti/drishti/Context.cpp
@@ -21,18 +21,23 @@ Context::Impl::Impl(drishti::sdk::SensorModel& sensor)
     , logger(drishti::core::Logger::create(DRISHTI_LOGGER_NAME))
     , threads(std::make_shared<tp::ThreadPool<>>()) // thread-pool
 {
-#if defined(_WIN32) || defined(_WIN64)
-    // A windows DLL must call glewInit() from within the library (not the application layer)
-    CV_Assert(wglGetCurrentContext() != NULL && GLEW_OK == glewInit());
-#endif  
 }
 
 Context::Context(drishti::sdk::SensorModel& sensor)
 {
     impl = drishti::core::make_unique<Impl>(sensor);
+    updateGL();
 }
 
 Context::~Context() = default;
+
+void Context::updateGL()
+{
+#if defined(_WIN32) || defined(_WIN64)
+    // A windows DLL must call glewInit() from within the library (not the application layer)
+    CV_Assert(wglGetCurrentContext() != NULL && GLEW_OK == glewInit());
+#endif  
+}
 
 void Context::setDoSingleFace(bool flag)
 {

--- a/src/lib/drishti/drishti/Context.hpp
+++ b/src/lib/drishti/drishti/Context.hpp
@@ -35,6 +35,8 @@ public:
 
     Impl* get() { return impl.get(); }
 
+    void updateGL();
+
     void setDoSingleFace(bool flag);
     bool getDoSingleFace() const;
 


### PR DESCRIPTION
* set CMAKE_INSTALL_RPATH w/ list syntax of string syntax
* add Context::updateGL() to allow use to call `glewInit()` from within windows DLL (requirement) for multi-context scenarios and bump minor sdk version
* add `add_library(drishti::drishti ALIAS drishti)` in install section for `add_subdirectory()` compatibility
* update `drishti-face-test` sample config file defaults
* update hunter to v0.21.15.tar.gz (for upload hunter upload retry w/ github api)

```
  set(CMAKE_INSTALL_RPATH "${DRISHTI_ORIGIN}/../lib" "${DRISHTI_ORIGIN}")
```