### PR TITLE
rework eye + face synchronization logic

### DIFF
--- a/src/app/hci/hci.cpp
+++ b/src/app/hci/hci.cpp
@@ -380,6 +380,7 @@ int gauze_main(int argc, char** argv)
     settings.renderEyesWidthRatio = 0.25f * opengl->getGeometry().sx; // *** rendering ***
     settings.doSingleFace = true;
     settings.doOptimizedPipeline = !doCpu;
+    settings.ignoreLatestFramesInMonitor = true;
  
     // The following parameters are set directly through the command line parser:
     //

--- a/src/app/sdk/face/FaceTrackerTest.h
+++ b/src/app/sdk/face/FaceTrackerTest.h
@@ -36,13 +36,34 @@ public:
 
     // Callback definitions: {
     int allocator(const drishti_image_t& spec, drishti::sdk::Image4b& image);
-    static int allocatorFunc(void* context, const drishti_image_t& spec, drishti::sdk::Image4b& image);
+    static int allocatorFunc
+    (
+        void* context,
+        const drishti_image_t& spec,
+        drishti::sdk::Image4b& image
+    );
 
     int callback(drishti::sdk::Array<drishti_face_tracker_result_t, 64>& results);
-    static int callbackFunc(void* context, drishti::sdk::Array<drishti_face_tracker_result_t, 64>& results);
+    static int callbackFunc
+    (
+        void* context,
+        drishti::sdk::Array<drishti_face_tracker_result_t, 64>& results
+     );
 
-    drishti_request_t trigger(const drishti_face_tracker_result_t& faces, double timestamp, std::uint32_t tex);
-    static drishti_request_t triggerFunc(void* context, const drishti_face_tracker_result_t& faces, double timestamp, std::uint32_t tex);
+    drishti_request_t trigger
+    (
+        const drishti_face_tracker_result_t& faces,
+        double timestamp,
+        std::uint32_t tex
+    );
+    
+    static drishti_request_t triggerFunc
+    (
+        void* context,
+        const drishti_face_tracker_result_t& faces,
+        double timestamp,
+        std::uint32_t tex
+    );
     // }
 
     // A user definable stack operation, with a default implementatino that performs

--- a/src/lib/drishti/drishti/FaceMonitorAdapter.h
+++ b/src/lib/drishti/drishti/FaceMonitorAdapter.h
@@ -78,13 +78,24 @@ public:
 
     ~FaceMonitorAdapter() = default;
 
+    static Request convert(const drishti_request_t &request)
+    {
+        return Request
+        {
+            request.n,
+            request.getImage,
+            request.getTexture,
+            request.getFrames,
+            request.getEyes
+        };
+    }
+
     virtual Request request(const Faces& faces, const TimePoint& timeStamp, std::uint32_t texture)
     {
         double elapsed = std::chrono::duration_cast<std::chrono::duration<double>>(timeStamp - m_start).count();
         drishti_face_tracker_result_t result;
         convert(faces, result.faceModels);
-        auto request = m_table.update(m_table.context, result, elapsed, texture);
-        return Request{ request.n, request.getImage, request.getTexture, request.getFrames, request.getEyes };
+        return convert(m_table.update(m_table.context, result, elapsed, texture));
     }
 
     virtual void grab(const std::vector<FaceImage>& frames, bool isInitialized)

--- a/src/lib/drishti/drishti/FaceTracker.cpp
+++ b/src/lib/drishti/drishti/FaceTracker.cpp
@@ -178,7 +178,11 @@ _DRISHTI_SDK_END
 DRISHTI_EXTERN_C_BEGIN
 
 DRISHTI_EXPORT drishti::sdk::FaceTracker*
-drishti_face_tracker_create_from_streams(drishti::sdk::Context* manager, drishti::sdk::FaceTracker::Resources& resources)
+drishti_face_tracker_create_from_streams
+(
+    drishti::sdk::Context* manager,
+    drishti::sdk::FaceTracker::Resources& resources
+)
 {
     return new drishti::sdk::FaceTracker(manager, resources);
 }
@@ -193,7 +197,11 @@ drishti_face_tracker_destroy(drishti::sdk::FaceTracker*& tracker)
 }
 
 DRISHTI_EXPORT int
-drishti_face_tracker_callback(drishti::sdk::FaceTracker* tracker, drishti_face_tracker_t& table)
+drishti_face_tracker_callback
+(
+    drishti::sdk::FaceTracker* tracker,
+    drishti_face_tracker_t& table
+)
 {
     if (tracker)
     {

--- a/src/lib/drishti/drishti/FaceTracker.hpp
+++ b/src/lib/drishti/drishti/FaceTracker.hpp
@@ -173,7 +173,12 @@ typedef int (*drishti_face_tracker_callback_t)(void* context, drishti_face_track
  * @return A request structure for frame history + associated metadata.
  */
 typedef drishti_request_t (*drishti_face_tracker_update_t)
-(void* context, const drishti_face_tracker_result_t& faces, double timestamp, std::uint32_t texture);
+(
+    void* context,
+    const drishti_face_tracker_result_t& faces,
+    double timestamp,
+    std::uint32_t texture
+);
 
 /** 
  * @brief Allocation routine.
@@ -186,7 +191,11 @@ typedef drishti_request_t (*drishti_face_tracker_update_t)
  * @return Error code (reserved).
  */
 typedef int (*drishti_face_tracker_allocator_t)
-(void* context, const drishti_image_t& spec, drishti::sdk::Image4b& image);
+(
+    void* context,
+    const drishti_image_t& spec,
+    drishti::sdk::Image4b& image
+);
 
 /**
  * @brief A table of user defined callbacks to assist in face tracking.
@@ -296,6 +305,7 @@ public:
     void add(drishti_face_tracker_t& table);
 
 protected:
+    
     struct Impl;
     std::unique_ptr<Impl> m_impl;
 };
@@ -319,7 +329,11 @@ DRISHTI_EXTERN_C_BEGIN
  */
 
 DRISHTI_EXPORT drishti::sdk::FaceTracker*
-drishti_face_tracker_create_from_streams(drishti::sdk::Context* manager, drishti::sdk::FaceTracker::Resources& resources);
+drishti_face_tracker_create_from_streams
+(
+    drishti::sdk::Context* manager,
+    drishti::sdk::FaceTracker::Resources& resources
+);
 
 /**
  * @brief Stream based deallocation of FaceTracker
@@ -343,7 +357,11 @@ drishti_face_tracker_destroy(drishti::sdk::FaceTracker*& tracker);
  */
 
 DRISHTI_EXPORT int
-drishti_face_tracker_track(drishti::sdk::FaceTracker* tracker, const drishti::sdk::VideoFrame& frame);
+drishti_face_tracker_track
+(
+    drishti::sdk::FaceTracker* tracker,
+    const drishti::sdk::VideoFrame& frame
+);
 
 /**
  * @brief Define a set of callbacks to return face tracking results.
@@ -362,7 +380,11 @@ drishti_face_tracker_track(drishti::sdk::FaceTracker* tracker, const drishti::sd
  */
 
 DRISHTI_EXPORT int
-drishti_face_tracker_callback(drishti::sdk::FaceTracker* tracker, drishti_face_tracker_t& table);
+drishti_face_tracker_callback
+(
+    drishti::sdk::FaceTracker* tracker,
+    drishti_face_tracker_t& table
+);
 
 DRISHTI_EXTERN_C_END
 

--- a/src/lib/drishti/face/gpu/EyeFilter.h
+++ b/src/lib/drishti/face/gpu/EyeFilter.h
@@ -92,10 +92,13 @@ public:
     {
         m_faces.push_back(face);
     }
+    
+    void clearFaces()
+    {
+        m_faces.clear();
+    }
 
     void dump(std::vector<cv::Mat4b>& images, std::vector<EyePair>& eyes, int n, bool getImage);
-
-    void renderIris();
 
 protected:
     int m_history = 3;

--- a/src/lib/drishti/hci/FaceFinder.h
+++ b/src/lib/drishti/hci/FaceFinder.h
@@ -106,6 +106,8 @@ public:
         float renderEyesWidthRatio = 0.25f;
 
         int history = DRISHTI_HCI_FACEFINDER_HISTORY;
+        
+        bool ignoreLatestFramesInMonitor = false;
     };
 
     FaceFinder(FaceDetectorFactoryPtr& factory, Settings& config, void* glContext = nullptr);
@@ -167,7 +169,7 @@ protected:
     void init2(drishti::face::FaceDetectorFactory& resources);
 
     void dumpEyes(ImageViews& frames, EyeModelPairs& eyes, int n = 1, bool getImage = false);
-    void dumpFaces(ImageViews& frames, int n = 1, bool getImage = false);
+    void dumpFaces(ImageViews& frames, int n = 1, bool getImage = false, int skipFrames = 0);
     int detectOnly(ScenePrimitives& scene, bool doDetection);
     virtual int detect(const FrameInput& frame, ScenePrimitives& scene, bool doDetection);
     virtual GLuint paint(const ScenePrimitives& scene, GLuint inputTexture);

--- a/src/lib/drishti/hci/FaceFinderImpl.h
+++ b/src/lib/drishti/hci/FaceFinderImpl.h
@@ -95,6 +95,7 @@ struct FaceFinder::Impl
         , usePBO(args.usePBO)
         , doOptimizedPipeline(args.doOptimizedPipeline)
         , history(args.history)
+        , ignoreLatestFramesInMonitor(args.ignoreLatestFramesInMonitor)
     {
     }
 
@@ -210,6 +211,8 @@ struct FaceFinder::Impl
     // :::::::::::::::::::::::
     std::unique_ptr<ogles_gpgpu::TransformProc> warper;
     std::unique_ptr<ogles_gpgpu::TransformProc> rotater; // output frame rotation
+    
+    bool ignoreLatestFramesInMonitor = true;
 };
 
 DRISHTI_HCI_NAMESPACE_END

--- a/src/lib/drishti/hci/FaceMonitor.h
+++ b/src/lib/drishti/hci/FaceMonitor.h
@@ -68,7 +68,14 @@ public:
     struct Request
     {
         Request() = default;
-        Request(int n, bool getImage, bool getTexture, bool getFrames=true, bool getEyes=true)
+        Request
+        (
+            int n,
+            bool getImage,
+            bool getTexture,
+            bool getFrames=true,
+            bool getEyes=true
+         )
             : n(n)
             , getImage(getImage)
             , getTexture(getTexture)
@@ -77,11 +84,11 @@ public:
         {
         }
 
-        int n = 0;               //! Number of frames requested (last n)
-        bool getImage = false;   //! Request an image (typically incurs some overhead)
-        bool getTexture = false; //! Request a texture (typically no overhead)
-        bool getFrames = true;   //! Retrieve frame textures or images
-        bool getEyes = true;     //! Retrieve eye textures or images
+        int n = 0;                //! Number of frames requested (last n)
+        bool getImage = false;    //! Request an image (typically incurs some overhead)
+        bool getTexture = false;  //! Request a texture (typically no overhead)
+        bool getFrames = true;    //! Retrieve frame textures or images
+        bool getEyes = true;      //! Retrieve eye textures or images
 
         Request& operator|=(const Request& src)
         {


### PR DESCRIPTION
See https://github.com/elucideye/drishti/issues/669 for time sequence FIFO dump montages illustrating updated face/frame + eye synchronization behavior.

Since the optimized pipeline (`FaceFinder::runFast()`) has a build in `latency == 2`, if the user requests a history of `N`, we configure the main video frame FIFO to be `N + latency`.   So for `N=3` we would have a `fifo.length() == 3+2 == 5`.  Previously, in the optimized pipeline mode, the first two frames would be returned without eye pairs (those ones are still being processed asynchronously).  This PR adds an `ignoreLatestFramesInMonitor` member variable to `FaceFinder` (and public `FaceTracker` counterpart) to control whether or not the leading frames will be included in the user requested `N` frames or not.  Given the config above, If `ignoreLatestFramesInMonitor==true`, then if the user requests `3` frames it will be assumed that they are only interested in the frames with paired metadata, so the first `2` frames will not be returned in the vector.  The user can set `ignoreLatestFramesInMonitor=false` to return to the old behavior, in which case the leading two frames will be returned even though they have no associated metadata or eye textures.  The `ignoreLatestFramesInMonitor` variable has no impact if the simple pipeline (`FaceFinder::runSimple()`) is being used, since it has no built-in latency.

Summary:

* rework face/frame + eye + metadata synchronization
* c++ formatting (reduce some longer prototypes)
* in `Facefinder::init()` the latency member initialization is initialized first and we rely on this for FIFO initialization (in particular, we allocate the full frame FIFO to be `latency + history` if we are using the optimized pipeline
* add `FaceFinder::Impl::ignoreLatestFramesInMonitor` (see texture above) and set to true by default
* remove unused